### PR TITLE
Fix typo 'nessassary' in docs

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,11 +1,11 @@
-#DISCORD SETTINGS (nessassary for show up streamers and categorizing them)
+#DISCORD SETTINGS (necessary for show up streamers and categorizing them)
 DISCORD_TOKEN=
 REPORTS_DISCORD_CHANNEL_ID=
 UNWANTED_DISCORD_CHANNEL_ID=
 1ST_WARN_DISCORD_CHANNEL_ID=
 2ND_WARN_DISCORD_CHANNEL_ID=
 
-#TWITCH API SETTINGS (nessassary for show up streamers)
+#TWITCH API SETTINGS (necessary for show up streamers)
 TWITCH_CLIENT_ID=
 TWITCH_CLIENT_SECRET=
 STREAM_GAME_ID=

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ venv\Scripts\activate  # For Windows
 
 ### 4. Setup .env
 ```
-#DISCORD SETTINGS (nessassary for show up streamers and categorizing them)
+#DISCORD SETTINGS (necessary for show up streamers and categorizing them)
 DISCORD_TOKEN=
 REPORTS_DISCORD_CHANNEL_ID=
 UNWANTED_DISCORD_CHANNEL_ID=
 1ST_WARN_DISCORD_CHANNEL_ID=
 2ND_WARN_DISCORD_CHANNEL_ID=
 
-#TWITCH API SETTINGS (nessassary for show up streamers)
+#TWITCH API SETTINGS (necessary for show up streamers)
 TWITCH_CLIENT_ID=
 TWITCH_CLIENT_SECRET=
 STREAM_GAME_ID=


### PR DESCRIPTION
## Summary
- fix `nessassary` typo in README
- fix same typo in `.env.dist`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685a45dd43408328b91fb4d30dc1c530