### PR TITLE
Add basic search_in_rcon tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,9 @@ Embed Links
 ### 7. Running the Bot
 To start the bot, simply run:
 `python twitch-scouter.py`
+
+### Running Tests
+Run the unit tests with:
+```
+pytest -q
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord.py
 requests
 python-dotenv
 mysql-connector-python
+pytest

--- a/tests/test_rcon.py
+++ b/tests/test_rcon.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from bin.connection_rcon import search_in_rcon
+
+
+class DummyFollowup:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, message, ephemeral=False):
+        self.sent.append((message, ephemeral))
+
+
+class DummyInteraction:
+    def __init__(self):
+        self.followup = DummyFollowup()
+
+
+@patch('bin.connection_rcon.requests.get')
+def test_search_in_rcon_found(mock_get):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "result": {
+            "stats": [
+                {"player": "TestPlayerOne", "player_id": "123"},
+                {"player": "AnotherPlayer", "player_id": "456"},
+            ]
+        }
+    }
+    mock_resp.raise_for_status.return_value = None
+    mock_get.return_value = mock_resp
+
+    interaction = DummyInteraction()
+    result = asyncio.run(search_in_rcon('http://api', 'testplayerone', interaction, server_name='Server1'))
+
+    assert result is True
+    assert interaction.followup.sent == [
+        ("Server: Server1 - Player: TestPlayerOne, Player ID: 123", True)
+    ]
+
+@patch('bin.connection_rcon.requests.get')
+def test_search_in_rcon_not_found(mock_get):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "result": {
+            "stats": [
+                {"player": "OtherPlayer", "player_id": "789"}
+            ]
+        }
+    }
+    mock_resp.raise_for_status.return_value = None
+    mock_get.return_value = mock_resp
+
+    interaction = DummyInteraction()
+    result = asyncio.run(search_in_rcon('http://api', 'nonexistent', interaction, server_name='Server1'))
+
+    assert result is False
+    assert interaction.followup.sent == []


### PR DESCRIPTION
## Summary
- add unit tests for `search_in_rcon`
- document how to run tests in README
- include `pytest` in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4923afe88328bffcdc3a5128ac5f